### PR TITLE
feat: rename app to AudioTask Reminder

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.task_reminder_app"
+    namespace = "com.apps.audiotaskreminder"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.task_reminder_app"
+        applicationId = "com.apps.audiotaskreminder"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
          Without this, AlarmScreen silently fails to open from background. -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <application
-        android:label="Reminder App"
+        android:label="AudioTask Reminder"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/java/com/apps/audiotaskreminder/AlarmReceiver.java
+++ b/android/app/src/main/java/com/apps/audiotaskreminder/AlarmReceiver.java
@@ -1,4 +1,4 @@
-package com.example.task_reminder_app;
+package com.apps.audiotaskreminder;
 
 import android.app.Notification;
 import android.app.NotificationChannel;

--- a/android/app/src/main/java/com/apps/audiotaskreminder/BootReceiver.java
+++ b/android/app/src/main/java/com/apps/audiotaskreminder/BootReceiver.java
@@ -1,4 +1,4 @@
-package com.example.task_reminder_app;
+package com.apps.audiotaskreminder;
 
 import android.app.AlarmManager;
 import android.app.PendingIntent;

--- a/android/app/src/main/java/com/apps/audiotaskreminder/MainActivity.java
+++ b/android/app/src/main/java/com/apps/audiotaskreminder/MainActivity.java
@@ -1,4 +1,4 @@
-package com.example.task_reminder_app;
+package com.apps.audiotaskreminder;
 
 import android.app.AlarmManager;
 import android.app.NotificationManager;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -495,7 +495,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -513,7 +513,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -529,7 +529,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -661,7 +661,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -684,7 +684,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.taskReminderApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.apps.audiotaskreminder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Task Reminder App</string>
+	<string>AudioTask Reminder</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: task_reminder_app
-description: "A new Flutter project."
+name: audiotask_reminder
+description: "AudioTask Reminder App"
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
This PR implements the app + package rename requested in issue #4.\n\n**Changes:**\n- Android\n  - applicationId set to \ in \.\n  - \ updated to \.\n  - \ in \ changed to \.\n  - Java package updated to \ and sources moved to \.\n- iOS\n  - \ values updated to \ in \.\n  - Display name and bundle name will now be \ (once you adjust CFBundleName if desired).\n- Flutter\n  - \ name changed to \.\n  - Description updated to \.\n\n> Note: I couldn't run \ here (no Flutter CLI in this environment), so please run Android/iOS builds locally to confirm everything passes.\n\nThis addresses issue #4 (change application name & package name).